### PR TITLE
Support flake8 --show-source

### DIFF
--- a/flake8_formatter_junit_xml/formatter.py
+++ b/flake8_formatter_junit_xml/formatter.py
@@ -21,15 +21,17 @@ class JUnitXmlFormatter(base.BaseFormatter):
     def handle(self, error):
         name = '{0}, {1}'.format(error.code, error.text)
         test_case = TestCase(name, file=error.filename, line=error.line_number)
-        message = '%(path)s:%(row)d:%(col)d: %(code)s %(text)s' % {
+        test_case.add_failure_info(message=self.format(error), output=self.show_source(error))
+        self.test_suites[error.filename].test_cases.append(test_case)
+
+    def format(self, error):
+        return '%(path)s:%(row)d:%(col)d: %(code)s %(text)s' % {
             "code": error.code,
             "text": error.text,
             "path": error.filename,
             "row": error.line_number,
             "col": error.column_number,
         }
-        test_case.add_failure_info(message)
-        self.test_suites[error.filename].test_cases.append(test_case)
 
     # Add a dummy test if no error found
     def finished(self, filename):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -13,6 +13,7 @@ error = style_guide.Violation('A000', filename, 2, 1, 'wrong wrong wrong', 'impo
 def create_formatter(**kwargs):
     kwargs.setdefault('output_file', None)
     kwargs.setdefault('tee', False)
+    kwargs.setdefault('show_source', False)
     return JUnitXmlFormatter(optparse.Values(kwargs))
 
 
@@ -30,6 +31,13 @@ class TestJunitXmlFormatter(unittest.TestCase):
         f.handle(error)
         self.assertIsNotNone(f.test_suites[filename].test_cases)
         self.assertIsInstance(f.test_suites[filename].test_cases[0], TestCase)
+        self.assertIsNone(f.test_suites[filename].test_cases[0].failure_output)
+
+    def test_show_source(self):
+        f = create_formatter(show_source=True)
+        f.beginning(filename)
+        f.handle(error)
+        self.assertIn('import os', f.test_suites[filename].test_cases[0].failure_output)
 
     def test_scenario(self):
         (fd, tempfilename) = tempfile.mkstemp()


### PR DESCRIPTION
http://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-show-source:

> Print the source code generating the error/warning in question.