### PR TITLE
print to stdout with default format

### DIFF
--- a/flake8_formatter_junit_xml/formatter.py
+++ b/flake8_formatter_junit_xml/formatter.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from flake8.formatting import base, default
 import optparse
 from junit_xml import TestSuite, TestCase

--- a/flake8_formatter_junit_xml/formatter.py
+++ b/flake8_formatter_junit_xml/formatter.py
@@ -8,8 +8,6 @@ class JUnitXmlFormatter(default.Default):
 
     def after_init(self):
         self.test_suites = {}
-
-    def after_init(self):
         self.options.format = "default" # so that DefaultFormatter uses their built-in format
         super().after_init()
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -5,7 +5,12 @@ import sys
 import tempfile
 from flake8_formatter_junit_xml import JUnitXmlFormatter
 from flake8 import style_guide
-from io import StringIO
+try:
+    # This is for Python2 only.
+    from StringIO import StringIO
+except ImportError:
+    # This also exists in Python2 but printing to it causes unicode errors.
+    from io import StringIO
 from junit_xml import TestSuite, TestCase
 
 filename = 'some/filename.py'

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,9 +1,11 @@
 import unittest
 import optparse
 import os
+import sys
 import tempfile
 from flake8_formatter_junit_xml import JUnitXmlFormatter
 from flake8 import style_guide
+from io import StringIO
 from junit_xml import TestSuite, TestCase
 
 filename = 'some/filename.py'
@@ -26,6 +28,9 @@ class TestJunitXmlFormatter(unittest.TestCase):
         self.assertEqual('flake8.some/filename_py', f.test_suites[filename].name)
 
     def test_handle(self):
+        io = StringIO()
+        sys.stdout = io
+
         f = create_formatter()
         f.beginning(filename)
         f.handle(error)
@@ -33,13 +38,19 @@ class TestJunitXmlFormatter(unittest.TestCase):
         self.assertIsInstance(f.test_suites[filename].test_cases[0], TestCase)
         self.assertIsNone(f.test_suites[filename].test_cases[0].failure_output)
 
+        self.assertEqual(io.getvalue(), "some/filename.py:2:1: A000 wrong wrong wrong\n")
+        sys.stdout = sys.__stdout__
+
     def test_show_source(self):
         f = create_formatter(show_source=True)
         f.beginning(filename)
         f.handle(error)
         self.assertIn('import os', f.test_suites[filename].test_cases[0].failure_output)
 
-    def test_scenario(self):
+    def test_scenario_xml_file_only(self):
+        io = StringIO()
+        sys.stdout = io
+
         (fd, tempfilename) = tempfile.mkstemp()
 
         # If formatter opens this file with `a`, tests should fail due to pre-written content.
@@ -65,4 +76,41 @@ class TestJunitXmlFormatter(unittest.TestCase):
             # print(content)
             self.assertEqual(xml_content, content)
 
+        self.assertEqual(io.getvalue(), '')
+
         os.remove(tempfilename)
+        sys.stdout = sys.__stdout__
+
+    def test_scenario_with_tee(self):
+        io = StringIO()
+        sys.stdout = io
+
+        (fd, tempfilename) = tempfile.mkstemp()
+
+        # If formatter opens this file with `a`, tests should fail due to pre-written content.
+        with os.fdopen(fd, 'w') as f:
+            f.write("some pre-existing texts!!\n")
+
+        with open(os.path.dirname(os.path.abspath(__file__)) + '/expected.xml', 'r') as f:
+            xml_content = f.read()
+
+        formatter = create_formatter(output_file=tempfilename, tee=True)
+        formatter.start()
+        # a file with error
+        formatter.beginning(filename)
+        formatter.handle(error)
+        formatter.finished(filename)
+        # another file without error
+        formatter.beginning("some/noerror.py")
+        formatter.finished("some/noerror.py")
+        formatter.stop()
+
+        with open(tempfilename) as f:
+            content = f.read()
+            # print(content)
+            self.assertEqual(xml_content, content)
+
+        self.assertEqual(io.getvalue(), "some/filename.py:2:1: A000 wrong wrong wrong\n")
+
+        os.remove(tempfilename)
+        sys.stdout = sys.__stdout__


### PR DESCRIPTION
#10.

breaking change, but I hope acceptable.

Currently this formatter print to stdout with xml format, but with this p-r it will print to stdout with default format and to file with junit-xml format. tricky?