### PR TITLE
Exclude tests from installed package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     author="Asato Wakisaka",
     author_email="asato.wakisaka@gmail.com",
     url="https://github.com/astj/flake8-formatter-junit-xml",
-    packages=setuptools.find_packages(exclude=['examples']),
+    packages=setuptools.find_packages(exclude=['examples', 'tests']),
     install_requires=requires,
     entry_points={
         'flake8.report': [


### PR DESCRIPTION
Currently, this library ships a `tests` package that in some circumstances can shadow imports for a local `tests` module.